### PR TITLE
手动退出脚本

### DIFF
--- a/core/Ant_forest.js
+++ b/core/Ant_forest.js
@@ -416,6 +416,7 @@ function Ant_forest(automator, unlock) {
         }
       }
       thread.interrupt();
+      exit()
     }
   }
 }


### PR DESCRIPTION
小米4c必须在这里显示调用exit()，否则即使没有任务要完成了，脚本还是处于运行状态，而当前版本不允许重复运行脚本。